### PR TITLE
refactor: secure pull-votes API key

### DIFF
--- a/scripts/pull-votes.mjs
+++ b/scripts/pull-votes.mjs
@@ -49,7 +49,9 @@ function offendersFromRoll(roll){
 
 async function collectChamber(chamber){
   const out = {};
-  let url = `${BASE}/votes/${chamber}?fromDateTime=${encodeURIComponent(sinceISO)}&format=json&api_key=${KEY}`;
+  // The API key is provided via header, so avoid leaking it in the request URL
+  // which could be logged or cached. Rely solely on the header for auth.
+  let url = `${BASE}/votes/${chamber}?fromDateTime=${encodeURIComponent(sinceISO)}&format=json`;
   while (url) {
     const data = await getJSON(url);
     for (const v of data.votes || []) {


### PR DESCRIPTION
## Summary
- avoid leaking API key in `pull-votes.mjs`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run validate` *(fails: Cannot find module '/workspace/congressv2/scripts/validate.mjs')*


------
https://chatgpt.com/codex/tasks/task_e_68acd75bd384832385bdd33a0127ed28