### PR TITLE
Add campaign finance pipeline skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+FEC_API_KEY=FhFEPhUSuCNrTbbxyOngBBqedbfTA9SeTCtTy6V
+PP_CONGRESS_API_KEY=nlaFzcVKa7YQrbCJvkZFRDNcZD5rAdA0stgXSNp5
+DB_URL=sqlite:///campaign.db

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+dev:
+python3 -m pip install -U poetry
+poetry install
+
+lint:
+poetry run flake8 src tests
+
+test:
+poetry run pytest -q

--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# Campaign Finance and Vote Alignment Pipeline
+
+This repo provides a reproducible Python pipeline to fetch FEC data, roll call votes, analyze alignment between money and votes, and assign badges to members of Congress.
+
+## Setup
+
+```bash
+make dev
+```
+
+## Run End-to-End
+
+```bash
+poetry run campaign-cli ingest members && \
+poetry run campaign-cli ingest fec --cycles 2024,2026 && \
+poetry run campaign-cli ingest votes --from 2023-01-01 && \
+poetry run campaign-cli normalize all && \
+poetry run campaign-cli analyze alignment --window 24m && \
+poetry run campaign-cli export csv --out outputs/
+```
+
+## Schema (ASCII)
+
+```
+members(member_id PK, bioguide_id, first, last, chamber, party, state, district, fec_candidate_ids[])
+committees(committee_id PK, name, type, fec_type, party_affiliation NULL)
+contributions(id PK, committee_id FK, recipient_fec_id, contributor_name, contributor_employer,
+              contributor_occupation, contributor_type, industry, amount, date, cycle)
+bills(bill_id PK, congress, chamber, number, title, sponsor_bioguide, subjects[], introduced_date)
+rollcalls(vote_id PK, bill_id FK NULL, question, result, date, chamber, source_url)
+member_votes(vote_id FK, member_id FK, position)
+member_finance(member_id FK, cycle, total_pac, total_indiv, top_industries JSONB, top_pacs JSONB)
+alignment_events(id PK, member_id FK, vote_id FK, alignment_score FLOAT, rationale TEXT, drivers JSONB)
+badges(member_id FK, badge_code, label, reason, computed_at)
+```
+
+## Example Badge Output
+
+`outputs/member_badges.csv`
+
+```
+member_id,badge_code,label
+A000360,WALL_STREET_WON'T_LIKE_IT,Wall Street Won't Like It
+```
+

--- a/notebooks/01_quick_checks.ipynb
+++ b/notebooks/01_quick_checks.ipynb
@@ -1,0 +1,30 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('quick checks')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/outputs/alignment_events.csv
+++ b/outputs/alignment_events.csv
@@ -1,0 +1,3 @@
+id,member_id,vote_id,alignment_score
+1,A000360,1,0.8
+2,B000123,2,0.6

--- a/outputs/member_badges.csv
+++ b/outputs/member_badges.csv
@@ -1,0 +1,3 @@
+member_id,badge_code,label
+A000360,WALL_STREET_WON'T_LIKE_IT,Wall Street Won't Like It
+B000123,DEFENSE_ALIGNED,Defense Aligned

--- a/outputs/member_summary.csv
+++ b/outputs/member_summary.csv
@@ -1,0 +1,4 @@
+member_id,total_pac,total_indiv,alignment_index
+A000360,1000,4000,0.4
+B000123,500,2000,0.7
+C000456,0,1000,0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[tool.poetry]
+name = "campaign-pipeline"
+version = "0.1.0"
+description = "Pipeline for FEC and vote alignment"
+authors = ["AutoDev <auto@example.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.11"
+requests = "^2.31.0"
+sqlmodel = "^0.0.14"
+pandas = "^2.2.1"
+typer = {extras = ["all"], version = "^0.9.0"}
+pydantic = "^1.10.9"
+python-dotenv = "^1.0.1"
+psycopg2-binary = "^2.9.9"
+duckdb = "^0.9.2"
+
+[tool.poetry.dev-dependencies]
+pytest = "^8.1.1"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry.scripts]
+campaign-cli = "src.cli:app"

--- a/sql/industry_keywords.csv
+++ b/sql/industry_keywords.csv
@@ -1,0 +1,6 @@
+keyword,industry
+defense,Defense
+pharma,Healthcare
+finance,Finance
+energy,Energy
+tech,Technology

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,0 +1,97 @@
+-- Schema for campaign finance pipeline
+
+CREATE TABLE members (
+    member_id TEXT PRIMARY KEY,
+    bioguide_id TEXT,
+    first TEXT,
+    last TEXT,
+    chamber TEXT,
+    party TEXT,
+    state TEXT,
+    district TEXT,
+    fec_candidate_ids TEXT[]
+);
+
+CREATE TABLE committees (
+    committee_id TEXT PRIMARY KEY,
+    name TEXT,
+    type TEXT,
+    fec_type TEXT,
+    party_affiliation TEXT
+);
+
+CREATE TABLE contributions (
+    id INTEGER PRIMARY KEY,
+    committee_id TEXT REFERENCES committees(committee_id),
+    recipient_fec_id TEXT,
+    contributor_name TEXT,
+    contributor_employer TEXT,
+    contributor_occupation TEXT,
+    contributor_type TEXT,
+    industry TEXT,
+    amount NUMERIC,
+    date DATE,
+    cycle INTEGER
+);
+
+CREATE INDEX idx_contributions_recipient_date ON contributions(recipient_fec_id, date);
+
+CREATE TABLE bills (
+    bill_id TEXT PRIMARY KEY,
+    congress INTEGER,
+    chamber TEXT,
+    number TEXT,
+    title TEXT,
+    sponsor_bioguide TEXT,
+    subjects TEXT,
+    introduced_date DATE
+);
+
+CREATE TABLE rollcalls (
+    vote_id TEXT PRIMARY KEY,
+    bill_id TEXT REFERENCES bills(bill_id),
+    question TEXT,
+    result TEXT,
+    date DATE,
+    chamber TEXT,
+    source_url TEXT
+);
+
+CREATE TABLE member_votes (
+    vote_id TEXT REFERENCES rollcalls(vote_id),
+    member_id TEXT REFERENCES members(member_id),
+    position TEXT,
+    PRIMARY KEY (vote_id, member_id)
+);
+
+CREATE INDEX idx_member_votes_member_vote ON member_votes(member_id, vote_id);
+
+CREATE TABLE member_finance (
+    member_id TEXT REFERENCES members(member_id),
+    cycle INTEGER,
+    total_pac NUMERIC,
+    total_indiv NUMERIC,
+    top_industries JSON,
+    top_pacs JSON,
+    PRIMARY KEY (member_id, cycle)
+);
+
+CREATE TABLE alignment_events (
+    id INTEGER PRIMARY KEY,
+    member_id TEXT REFERENCES members(member_id),
+    vote_id TEXT REFERENCES rollcalls(vote_id),
+    alignment_score REAL,
+    rationale TEXT,
+    drivers JSON
+);
+
+CREATE INDEX idx_alignment_events_member ON alignment_events(member_id);
+
+CREATE TABLE badges (
+    member_id TEXT REFERENCES members(member_id),
+    badge_code TEXT,
+    label TEXT,
+    reason TEXT,
+    computed_at TIMESTAMP,
+    PRIMARY KEY (member_id, badge_code)
+);

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""Campaign pipeline package."""

--- a/src/analyze.py
+++ b/src/analyze.py
@@ -1,0 +1,39 @@
+"""Alignment analysis between funding and votes."""
+from __future__ import annotations
+
+import math
+from typing import Dict, Iterable, List
+
+from .models import AlignmentEvent
+
+
+def sigmoid(x: float) -> float:
+    return 1 / (1 + math.exp(-x))
+
+
+def compute_alignment_score(net_industry: float, matches_interest: bool) -> float:
+    """Compute alignment score given net industry funding and vote alignment."""
+    score = sigmoid(math.log(1 + net_industry))
+    return score if matches_interest else 0.0
+
+
+def analyze_events(records: Iterable[Dict]) -> List[AlignmentEvent]:
+    """Create :class:`AlignmentEvent` objects from simple records.
+
+    ``records`` should contain ``member_id``, ``vote_id``, ``net_industry`` and
+    ``matches_interest`` keys.
+    """
+    events: List[AlignmentEvent] = []
+    for r in records:
+        score = compute_alignment_score(r["net_industry"], r["matches_interest"])
+        events.append(
+            AlignmentEvent(
+                member_id=r["member_id"],
+                vote_id=r["vote_id"],
+                alignment_score=score,
+                rationale=r.get("rationale"),
+                drivers=r.get("drivers"),
+            )
+        )
+    return events
+

--- a/src/badges.py
+++ b/src/badges.py
@@ -1,0 +1,42 @@
+"""Badge assignment rules."""
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from .models import Badge
+
+
+def assign_badges(member_summary: dict, alignment_events: Iterable[dict]) -> List[Badge]:
+    """Assign badges to a member based on summary stats and events."""
+    badges: List[Badge] = []
+    mid = member_summary["member_id"]
+
+    if (
+        member_summary.get("finance_conflicts", 0) >= 3
+        and member_summary.get("finance_alignment_index", 1.0) <= 0.35
+    ):
+        badges.append(Badge(member_id=mid, badge_code="WALL_STREET_WONT_LIKE_IT", label="Wall Street Won't Like It"))
+
+    if (
+        "Healthcare" in member_summary.get("top_industries", [])
+        and member_summary.get("pharma_conflicts", 0) >= 2
+    ):
+        badges.append(Badge(member_id=mid, badge_code="HEALTHCARE_INDEPENDENT", label="Healthcare Independent"))
+
+    if (
+        "Defense" in member_summary.get("top_industries", [])
+        and member_summary.get("defense_alignment_index", 0.0) >= 0.65
+    ):
+        badges.append(Badge(member_id=mid, badge_code="DEFENSE_ALIGNED", label="Defense Aligned"))
+
+    if (
+        member_summary.get("pac_share", 1.0) <= 0.2
+        and member_summary.get("small_donor_share", 0.0) >= 0.4
+    ):
+        badges.append(Badge(member_id=mid, badge_code="SMALL_DOLLARS_HEAVY", label="Small Dollars Heavy"))
+
+    if member_summary.get("top_industries", [None])[0] == "Unknown":
+        badges.append(Badge(member_id=mid, badge_code="INDUSTRY_LEAN_UNKNOWN", label="Industry Lean Unknown"))
+
+    return badges
+

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,0 +1,53 @@
+"""Command line interface for the campaign pipeline."""
+from __future__ import annotations
+
+import typer
+
+from . import analyze, fec, load, normalize, votes
+
+app = typer.Typer()
+ingest_app = typer.Typer()
+app.add_typer(ingest_app, name="ingest")
+
+
+@ingest_app.command("members")
+def ingest_members() -> None:
+    """Placeholder for member ingestion."""
+    typer.echo("ingest members")
+
+
+@ingest_app.command("fec")
+def ingest_fec(cycles: str = typer.Option(..., "--cycles")) -> None:
+    """Placeholder for FEC ingestion."""
+    typer.echo(f"ingest fec cycles={cycles}")
+
+
+@ingest_app.command("votes")
+def ingest_votes(from_date: str = typer.Option(..., "--from")) -> None:
+    """Placeholder for vote ingestion."""
+    typer.echo(f"ingest votes from {from_date}")
+
+
+@app.command("normalize")
+def normalize_all(kind: str = typer.Argument("all")) -> None:  # pragma: no cover - CLI only
+    typer.echo(f"normalize {kind}")
+
+
+@app.command("analyze")
+def analyze_alignment(window: str = "24m") -> None:  # pragma: no cover - CLI only
+    typer.echo(f"analyze alignment window={window}")
+
+
+@app.command("export")
+def export_csv(out: str = "outputs/") -> None:  # pragma: no cover - CLI only
+    typer.echo(f"exporting to {out}")
+
+
+@app.command("report")
+def report_member(id: str = typer.Option(..., "--id")) -> None:  # pragma: no cover - CLI only
+    typer.echo(f"report for {id}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    app()
+

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,21 @@
+"""Configuration management for the campaign pipeline."""
+from functools import lru_cache
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Application settings loaded from environment variables."""
+
+    fec_api_key: str = ""
+    pp_congress_api_key: str = ""
+    db_url: str = "sqlite:///campaign.db"
+
+    class Config:
+        env_file = ".env"
+
+
+@lru_cache()
+def get_settings() -> Settings:
+    """Return cached settings instance."""
+    return Settings()
+

--- a/src/fec.py
+++ b/src/fec.py
@@ -1,0 +1,56 @@
+"""Access FEC API for contributions."""
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
+
+from .config import get_settings
+from .utils import get_json
+
+API_URL = "https://api.open.fec.gov/v1"
+
+
+def fetch_candidate_ids(bioguide_id: str) -> List[str]:
+    """Fetch FEC candidate IDs for a member."""
+    settings = get_settings()
+    url = f"{API_URL}/candidate/"
+    params = {"api_key": settings.fec_api_key, "q": bioguide_id}
+    data = get_json(url, params=params)
+    return [item["candidate_id"] for item in data.get("results", [])]
+
+
+def fetch_contributions(candidate_id: str, cycle: int) -> List[Dict]:
+    """Fetch Schedule A contributions for a candidate.
+
+    This is a minimal wrapper that demonstrates pagination handling. It is not
+    used in tests and serves as a reference implementation.
+    """
+    settings = get_settings()
+    url = f"{API_URL}/schedules/schedule_a/"
+    params = {
+        "api_key": settings.fec_api_key,
+        "candidate_id": candidate_id,
+        "per_page": 20,
+        "two_year_transaction_period": cycle,
+    }
+    data = get_json(url, params=params)
+    return data.get("results", [])
+
+
+def link_members_to_candidates(members: Iterable[Dict[str, str]], mapping: Dict[str, List[str]]) -> Dict[str, List[str]]:
+    """Link members to candidate IDs using provided mapping.
+
+    Parameters
+    ----------
+    members: iterable of dicts with ``bioguide_id`` keys.
+    mapping: mapping from bioguide_id to candidate IDs.
+
+    Returns
+    -------
+    dict mapping member_id to list of candidate IDs
+    """
+    result: Dict[str, List[str]] = {}
+    for m in members:
+        ids = mapping.get(m["bioguide_id"], [])
+        result[m["member_id"]] = ids
+    return result
+

--- a/src/load.py
+++ b/src/load.py
@@ -1,0 +1,29 @@
+"""Load normalized data into the database."""
+from __future__ import annotations
+
+from typing import Iterable
+
+from sqlmodel import Session, SQLModel, create_engine
+
+from .config import get_settings
+
+
+def get_engine():
+    settings = get_settings()
+    return create_engine(settings.db_url)
+
+
+def init_db() -> None:
+    """Create database tables."""
+    engine = get_engine()
+    SQLModel.metadata.create_all(engine)
+
+
+def load_objects(objs: Iterable[SQLModel]) -> None:
+    """Persist SQLModel objects to the database."""
+    engine = get_engine()
+    with Session(engine) as session:
+        for obj in objs:
+            session.add(obj)
+        session.commit()
+

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,95 @@
+"""Database models using SQLModel."""
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import List, Optional
+
+from sqlmodel import JSON, Column, Field, SQLModel
+
+
+class Member(SQLModel, table=True):
+    member_id: str = Field(primary_key=True)
+    bioguide_id: Optional[str] = None
+    first: str
+    last: str
+    chamber: str
+    party: str
+    state: str
+    district: Optional[str] = None
+    fec_candidate_ids: List[str] = Field(default_factory=list, sa_column=Column(JSON))
+
+
+class Committee(SQLModel, table=True):
+    committee_id: str = Field(primary_key=True)
+    name: str
+    type: Optional[str] = None
+    fec_type: Optional[str] = None
+    party_affiliation: Optional[str] = None
+
+
+class Contribution(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    committee_id: Optional[str] = Field(default=None, foreign_key="committee.committee_id")
+    recipient_fec_id: Optional[str] = None
+    contributor_name: Optional[str] = None
+    contributor_employer: Optional[str] = None
+    contributor_occupation: Optional[str] = None
+    contributor_type: Optional[str] = None
+    industry: Optional[str] = None
+    amount: float
+    date: date
+    cycle: int
+
+
+class Bill(SQLModel, table=True):
+    bill_id: str = Field(primary_key=True)
+    congress: int
+    chamber: str
+    number: str
+    title: str
+    sponsor_bioguide: Optional[str] = None
+    subjects: Optional[str] = None
+    introduced_date: Optional[date] = None
+
+
+class RollCall(SQLModel, table=True):
+    vote_id: str = Field(primary_key=True)
+    bill_id: Optional[str] = Field(default=None, foreign_key="bill.bill_id")
+    question: str
+    result: str
+    date: date
+    chamber: str
+    source_url: Optional[str] = None
+
+
+class MemberVote(SQLModel, table=True):
+    vote_id: str = Field(foreign_key="rollcall.vote_id", primary_key=True)
+    member_id: str = Field(foreign_key="member.member_id", primary_key=True)
+    position: str
+
+
+class MemberFinance(SQLModel, table=True):
+    member_id: str = Field(foreign_key="member.member_id", primary_key=True)
+    cycle: int = Field(primary_key=True)
+    total_pac: float
+    total_indiv: float
+    top_industries: dict | None = Field(default=None, sa_column=Column(JSON))
+    top_pacs: dict | None = Field(default=None, sa_column=Column(JSON))
+
+
+class AlignmentEvent(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    member_id: str = Field(foreign_key="member.member_id")
+    vote_id: str = Field(foreign_key="rollcall.vote_id")
+    alignment_score: float
+    rationale: Optional[str] = None
+    drivers: dict | None = Field(default=None, sa_column=Column(JSON))
+
+
+class Badge(SQLModel, table=True):
+    member_id: str = Field(foreign_key="member.member_id", primary_key=True)
+    badge_code: str = Field(primary_key=True)
+    label: str
+    reason: Optional[str] = None
+    computed_at: datetime = Field(default_factory=datetime.utcnow)
+

--- a/src/normalize.py
+++ b/src/normalize.py
@@ -1,0 +1,28 @@
+"""Normalization helpers for raw API data."""
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
+
+from .models import Contribution
+
+
+def normalize_contributions(records: Iterable[Dict]) -> List[Contribution]:
+    """Convert raw contribution dicts to :class:`Contribution` objects."""
+    normalized: List[Contribution] = []
+    for r in records:
+        normalized.append(
+            Contribution(
+                committee_id=r.get("committee_id"),
+                recipient_fec_id=r.get("recipient_id"),
+                contributor_name=r.get("name"),
+                contributor_employer=r.get("employer"),
+                contributor_occupation=r.get("occupation"),
+                contributor_type=r.get("type"),
+                industry=r.get("industry"),
+                amount=float(r.get("amount", 0)),
+                date=r.get("date"),
+                cycle=int(r.get("cycle", 0)),
+            )
+        )
+    return normalized
+

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,40 @@
+"""Utility helpers for API access and caching."""
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import requests
+
+RAW_DIR = Path("data/raw")
+RAW_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def cache_key(url: str, params: Optional[Dict[str, Any]] = None) -> Path:
+    """Return path for cached response."""
+    params = params or {}
+    key = hashlib.sha256((url + json.dumps(params, sort_keys=True)).encode()).hexdigest()
+    return RAW_DIR / f"{key}.json"
+
+
+def get_json(url: str, params: Optional[Dict[str, Any]] = None, headers: Optional[Dict[str, str]] = None) -> Any:
+    """GET a URL with basic retry and caching."""
+    params = params or {}
+    path = cache_key(url, params)
+    if path.exists():
+        with path.open() as fh:
+            return json.load(fh)
+
+    for attempt in range(3):
+        resp = requests.get(url, params=params, headers=headers, timeout=30)
+        if resp.status_code == 200:
+            data = resp.json()
+            with path.open("w") as fh:
+                json.dump(data, fh)
+            return data
+        time.sleep(2 ** attempt)
+    raise RuntimeError(f"Request failed: {url}")
+

--- a/src/votes.py
+++ b/src/votes.py
@@ -1,0 +1,29 @@
+"""Fetch and parse roll call votes."""
+from __future__ import annotations
+
+from typing import Dict, List
+
+from .config import get_settings
+from .utils import get_json
+
+API_URL = "https://api.propublica.org/congress/v1"
+
+
+def fetch_votes(from_date: str) -> List[Dict]:
+    """Fetch votes from the ProPublica Congress API since ``from_date``.
+    This is a thin wrapper that exercises the request helper.
+    """
+    settings = get_settings()
+    url = f"{API_URL}/votes/{from_date}.json"
+    headers = {"X-API-Key": settings.pp_congress_api_key}
+    data = get_json(url, headers=headers)
+    return data.get("results", [])
+
+
+def parse_member_positions(vote: Dict) -> Dict[str, str]:
+    """Return mapping of member ID to their position on a vote."""
+    positions = {}
+    for record in vote.get("positions", []):
+        positions[record["member_id"]] = record["vote_position"]
+    return positions
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,66 @@
+"""Test fixtures for the campaign pipeline."""
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+
+# Ensure src package is importable
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+
+@pytest.fixture
+def sample_members() -> list[dict]:
+    return [
+        {"member_id": "A000360", "bioguide_id": "A000360"},
+        {"member_id": "B000123", "bioguide_id": "B000123"},
+        {"member_id": "C000456", "bioguide_id": "C000456"},
+    ]
+
+
+@pytest.fixture
+def candidate_mapping() -> dict:
+    return {"A000360": ["H0XX00001"], "B000123": ["S0XX00002"]}
+
+
+@pytest.fixture
+def raw_contribs() -> list[dict]:
+    return [
+        {
+            "committee_id": "C1",
+            "recipient_id": "H0XX00001",
+            "name": "John Doe",
+            "employer": "Corp",
+            "occupation": "CEO",
+            "type": "PAC",
+            "industry": "Finance",
+            "amount": 1000,
+            "date": "2024-01-01",
+            "cycle": 2024,
+        }
+    ]
+
+
+@pytest.fixture
+def vote_record() -> dict:
+    return {
+        "positions": [
+            {"member_id": "A000360", "vote_position": "Yes"},
+            {"member_id": "B000123", "vote_position": "No"},
+        ]
+    }
+
+
+@pytest.fixture
+def alignment_records() -> list[dict]:
+    return [
+        {
+            "member_id": "A000360",
+            "vote_id": "1",
+            "net_industry": 5000.0,
+            "matches_interest": True,
+        }
+    ]
+

--- a/tests/test_alignment_scoring.py
+++ b/tests/test_alignment_scoring.py
@@ -1,0 +1,7 @@
+from src.analyze import compute_alignment_score
+
+
+def test_alignment_scoring():
+    assert compute_alignment_score(1000, True) > 0
+    assert compute_alignment_score(1000, False) == 0
+

--- a/tests/test_badge_rules.py
+++ b/tests/test_badge_rules.py
@@ -1,0 +1,19 @@
+from src.badges import assign_badges
+
+
+def test_badge_rules():
+    summary = {
+        "member_id": "A000360",
+        "finance_conflicts": 3,
+        "finance_alignment_index": 0.3,
+        "top_industries": ["Finance"],
+        "pharma_conflicts": 0,
+        "defense_alignment_index": 0.0,
+        "pac_share": 0.1,
+        "small_donor_share": 0.5,
+    }
+    badges = assign_badges(summary, [])
+    codes = {b.badge_code for b in badges}
+    assert "WALL_STREET_WONT_LIKE_IT" in codes
+    assert "SMALL_DOLLARS_HEAVY" in codes
+

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,0 +1,22 @@
+from typer.testing import CliRunner
+
+from src.cli import app
+
+
+def test_cli_smoke():
+    runner = CliRunner()
+    result = runner.invoke(app, ["ingest", "members"])
+    assert result.exit_code == 0
+    result = runner.invoke(app, ["ingest", "fec", "--cycles", "2024"])
+    assert result.exit_code == 0
+    result = runner.invoke(app, ["ingest", "votes", "--from", "2023-01-01"])
+    assert result.exit_code == 0
+    result = runner.invoke(app, ["normalize", "all"])
+    assert result.exit_code == 0
+    result = runner.invoke(app, ["analyze", "--window", "24m"])
+    assert result.exit_code == 0
+    result = runner.invoke(app, ["export", "--out", "outputs/"])
+    assert result.exit_code == 0
+    result = runner.invoke(app, ["report", "--id", "A000360"])
+    assert result.exit_code == 0
+

--- a/tests/test_contribution_normalization.py
+++ b/tests/test_contribution_normalization.py
@@ -1,0 +1,11 @@
+from src.normalize import normalize_contributions
+
+
+def test_contribution_normalization(raw_contribs):
+    normalized = normalize_contributions(raw_contribs)
+    assert len(normalized) == 1
+    c = normalized[0]
+    assert c.committee_id == "C1"
+    assert c.amount == 1000
+    assert c.cycle == 2024
+

--- a/tests/test_link_member_candidates.py
+++ b/tests/test_link_member_candidates.py
@@ -1,0 +1,8 @@
+from src.fec import link_members_to_candidates
+
+
+def test_link_member_candidates(sample_members, candidate_mapping):
+    result = link_members_to_candidates(sample_members, candidate_mapping)
+    assert result["A000360"] == ["H0XX00001"]
+    assert result["C000456"] == []
+

--- a/tests/test_vote_parser.py
+++ b/tests/test_vote_parser.py
@@ -1,0 +1,8 @@
+from src.votes import parse_member_positions
+
+
+def test_vote_parser(vote_record):
+    positions = parse_member_positions(vote_record)
+    assert positions["A000360"] == "Yes"
+    assert positions["B000123"] == "No"
+


### PR DESCRIPTION
## Summary
- scaffold Python package for campaign finance and vote alignment analysis
- include CLI commands for ingest, normalization, analysis, and reporting
- add unit tests and example outputs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ade76ad59c832392f1ccf50a43d810