### PR TITLE
Clean pipeline CLI and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,6 @@ badges(member_id FK, badge_code, label, reason, computed_at)
 member_id,badge_code,label
 A000360,WALL_STREET_WON'T_LIKE_IT,Wall Street Won't Like It
 ```
-
- codex/create-reproducible-pipeline-for-fec-data-analysis-erh252
-
 ## Publish data for Accountability Wall
 
 After generating CSV outputs, convert them to JSON for the accountability cards:

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,26 +1,14 @@
 """Command line interface for the campaign pipeline."""
 from __future__ import annotations
 
- codex/create-reproducible-pipeline-for-fec-data-analysis-erh252
-
- codex/create-reproducible-pipeline-for-fec-data-analysis-bn84jr
- main
-import typer
-
-from . import analyze, fec, load, normalize, votes
-
- codex/create-reproducible-pipeline-for-fec-data-analysis-erh252
-
 import csv
 from pathlib import Path
 
 import typer
 
 from . import analyze, fec, load, normalize, votes
-from .models import AlignmentEvent, Member, MemberVote
- main
+from .models import Member, MemberVote
 
- main
 app = typer.Typer()
 ingest_app = typer.Typer()
 app.add_typer(ingest_app, name="ingest")
@@ -28,47 +16,6 @@ app.add_typer(ingest_app, name="ingest")
 
 @ingest_app.command("members")
 def ingest_members() -> None:
- codex/create-reproducible-pipeline-for-fec-data-analysis-erh252
-    """Placeholder for member ingestion."""
-    typer.echo("ingest members")
-
-
-@ingest_app.command("fec")
-def ingest_fec(cycles: str = typer.Option(..., "--cycles")) -> None:
-    """Placeholder for FEC ingestion."""
-    typer.echo(f"ingest fec cycles={cycles}")
-
-
-@ingest_app.command("votes")
-def ingest_votes(from_date: str = typer.Option(..., "--from")) -> None:
-    """Placeholder for vote ingestion."""
-    typer.echo(f"ingest votes from {from_date}")
-
-
-@app.command("normalize")
-def normalize_all(kind: str = typer.Argument("all")) -> None:  # pragma: no cover - CLI only
-    typer.echo(f"normalize {kind}")
-
-
-@app.command("analyze")
-def analyze_alignment(window: str = "24m") -> None:  # pragma: no cover - CLI only
-    typer.echo(f"analyze alignment window={window}")
-
-
-@app.command("export")
-def export_csv(out: str = "outputs/") -> None:  # pragma: no cover - CLI only
-    typer.echo(f"exporting to {out}")
-
-
-@app.command("report")
-def report_member(id: str = typer.Option(..., "--id")) -> None:  # pragma: no cover - CLI only
-    typer.echo(f"report for {id}")
-
-
- codex/create-reproducible-pipeline-for-fec-data-analysis-bn84jr
-    """Placeholder for member ingestion."""
-    typer.echo("ingest members")
-
     """Load a tiny set of members into the database."""
     load.init_db()
     members = [
@@ -92,19 +39,13 @@ def report_member(id: str = typer.Option(..., "--id")) -> None:  # pragma: no co
         ),
     ]
     load.load_objects(members)
- main
 
 
 @ingest_app.command("fec")
 def ingest_fec(cycles: str = typer.Option(..., "--cycles")) -> None:
- codex/create-reproducible-pipeline-for-fec-data-analysis-bn84jr
-    """Placeholder for FEC ingestion."""
-    typer.echo(f"ingest fec cycles={cycles}")
-
     """Normalize and store a sample FEC contribution record."""
     members = [{"member_id": "A000360", "bioguide_id": "A000360"}]
     mapping = {"A000360": ["H0XX00001"]}
-    # Link members to candidate IDs using the fec module
     fec.link_members_to_candidates(members, mapping)
     raw = [
         {
@@ -122,15 +63,10 @@ def ingest_fec(cycles: str = typer.Option(..., "--cycles")) -> None:
     ]
     contribs = normalize.normalize_contributions(raw)
     load.load_objects(contribs)
- main
 
 
 @ingest_app.command("votes")
 def ingest_votes(from_date: str = typer.Option(..., "--from")) -> None:
- codex/create-reproducible-pipeline-for-fec-data-analysis-bn84jr
-    """Placeholder for vote ingestion."""
-    typer.echo(f"ingest votes from {from_date}")
-
     """Parse and store a minimal vote record."""
     vote = {
         "vote_id": "1",
@@ -149,14 +85,10 @@ def ingest_votes(from_date: str = typer.Option(..., "--from")) -> None:
         for mid, pos in positions.items()
     ]
     load.load_objects(member_votes)
- main
 
 
 @app.command("normalize")
-def normalize_all(kind: str = typer.Argument("all")) -> None:  # pragma: no cover - CLI only
- codex/create-reproducible-pipeline-for-fec-data-analysis-bn84jr
-    typer.echo(f"normalize {kind}")
-
+def normalize_all(kind: str = typer.Argument("all")) -> None:  # pragma: no cover
     """Normalize a sample contribution record and store it."""
     raw = [
         {
@@ -174,14 +106,10 @@ def normalize_all(kind: str = typer.Argument("all")) -> None:  # pragma: no cove
     ]
     contribs = normalize.normalize_contributions(raw)
     load.load_objects(contribs)
- main
 
 
 @app.command("analyze")
-def analyze_alignment(window: str = "24m") -> None:  # pragma: no cover - CLI only
- codex/create-reproducible-pipeline-for-fec-data-analysis-bn84jr
-    typer.echo(f"analyze alignment window={window}")
-
+def analyze_alignment(window: str = "24m") -> None:  # pragma: no cover
     """Run a simple alignment analysis and store the event."""
     records = [
         {
@@ -193,14 +121,10 @@ def analyze_alignment(window: str = "24m") -> None:  # pragma: no cover - CLI on
     ]
     events = analyze.analyze_events(records)
     load.load_objects(events)
- main
 
 
 @app.command("export")
-def export_csv(out: str = "outputs/") -> None:  # pragma: no cover - CLI only
- codex/create-reproducible-pipeline-for-fec-data-analysis-bn84jr
-    typer.echo(f"exporting to {out}")
-
+def export_csv(out: str = "outputs/") -> None:  # pragma: no cover
     """Export alignment events to a CSV file."""
     Path(out).mkdir(parents=True, exist_ok=True)
     records = [
@@ -212,21 +136,16 @@ def export_csv(out: str = "outputs/") -> None:  # pragma: no cover - CLI only
         }
     ]
     events = analyze.analyze_events(records)
-    rows = [(ev.member_id, ev.vote_id, ev.alignment_score) for ev in events]
-    load.load_objects(events)
     path = Path(out) / "alignment.csv"
     with path.open("w", newline="") as fh:
         writer = csv.writer(fh)
         writer.writerow(["member_id", "vote_id", "alignment_score"])
-        writer.writerows(rows)
- main
+        for ev in events:
+            writer.writerow([ev.member_id, ev.vote_id, ev.alignment_score])
 
 
 @app.command("report")
-def report_member(id: str = typer.Option(..., "--id")) -> None:  # pragma: no cover - CLI only
- codex/create-reproducible-pipeline-for-fec-data-analysis-bn84jr
-    typer.echo(f"report for {id}")
-
+def report_member(id: str = typer.Option(..., "--id")) -> None:  # pragma: no cover
     """Emit a tiny alignment report for a member."""
     records = [
         {
@@ -241,10 +160,7 @@ def report_member(id: str = typer.Option(..., "--id")) -> None:  # pragma: no co
         typer.echo(
             f"member {ev.member_id} aligned on vote {ev.vote_id} score={ev.alignment_score:.2f}"
         )
- main
 
- main
 
-if __name__ == "__main__":  # pragma: no cover - manual execution
+if __name__ == "__main__":  # pragma: no cover
     app()
-

--- a/src/normalize.py
+++ b/src/normalize.py
@@ -1,21 +1,9 @@
 """Normalization helpers for raw API data."""
 from __future__ import annotations
 
- codex/create-reproducible-pipeline-for-fec-data-analysis-erh252
 from datetime import datetime
 from typing import Dict, Iterable, List
 
-
- codex/create-reproducible-pipeline-for-fec-data-analysis-bn84jr
-from datetime import datetime
-from typing import Dict, Iterable, List
-
-from datetime import date
-from typing import Dict, Iterable, List
-from datetime import datetime
- main
-
- main
 from .models import Contribution
 
 
@@ -23,23 +11,9 @@ def normalize_contributions(records: Iterable[Dict]) -> List[Contribution]:
     """Convert raw contribution dicts to :class:`Contribution` objects."""
     normalized: List[Contribution] = []
     for r in records:
- codex/create-reproducible-pipeline-for-fec-data-analysis-erh252
-
- codex/create-reproducible-pipeline-for-fec-data-analysis-bn84jr
- main
-        date_str = r.get("date")
-        parsed_date = (
-            datetime.strptime(date_str, "%Y-%m-%d").date() if date_str else None
-        )
- codex/create-reproducible-pipeline-for-fec-data-analysis-erh252
-
-
         date_val = r.get("date")
         if isinstance(date_val, str):
             date_val = datetime.strptime(date_val, "%Y-%m-%d").date()
-
- main
- main
         normalized.append(
             Contribution(
                 committee_id=r.get("committee_id"),
@@ -50,17 +24,8 @@ def normalize_contributions(records: Iterable[Dict]) -> List[Contribution]:
                 contributor_type=r.get("type"),
                 industry=r.get("industry"),
                 amount=float(r.get("amount", 0)),
- codex/create-reproducible-pipeline-for-fec-data-analysis-erh252
-                date=parsed_date,
-
- codex/create-reproducible-pipeline-for-fec-data-analysis-bn84jr
-                date=parsed_date,
-
-
- main
- main
+                date=date_val,
                 cycle=int(r.get("cycle", 0)),
             )
         )
     return normalized
-

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,39 +1,22 @@
- codex/create-reproducible-pipeline-for-fec-data-analysis-erh252
-
- codex/create-reproducible-pipeline-for-fec-data-analysis-bn84jr
-
 from pathlib import Path
 
- main
- main
 from typer.testing import CliRunner
 
 from src.cli import app
 
 
- codex/create-reproducible-pipeline-for-fec-data-analysis-erh252
-
- codex/create-reproducible-pipeline-for-fec-data-analysis-bn84jr
- main
-def test_cli_smoke():
-    runner = CliRunner()
-    result = runner.invoke(app, ["ingest", "members"])
-    assert result.exit_code == 0
- codex/create-reproducible-pipeline-for-fec-data-analysis-erh252
-
-
 def test_cli_smoke(tmp_path):
     runner = CliRunner()
+
+    # ingest members should create a database file
     db_path = Path("campaign.db")
     if db_path.exists():
         db_path.unlink()
     result = runner.invoke(app, ["ingest", "members"])
     assert result.exit_code == 0
-    # database should be created by ingest_members
     assert db_path.exists()
 
- main
- main
+    # run remaining commands to ensure CLI wiring works
     result = runner.invoke(app, ["ingest", "fec", "--cycles", "2024"])
     assert result.exit_code == 0
     result = runner.invoke(app, ["ingest", "votes", "--from", "2023-01-01"])
@@ -42,22 +25,11 @@ def test_cli_smoke(tmp_path):
     assert result.exit_code == 0
     result = runner.invoke(app, ["analyze", "--window", "24m"])
     assert result.exit_code == 0
- codex/create-reproducible-pipeline-for-fec-data-analysis-erh252
-    result = runner.invoke(app, ["export", "--out", "outputs/"])
-    assert result.exit_code == 0
-
- codex/create-reproducible-pipeline-for-fec-data-analysis-bn84jr
-    result = runner.invoke(app, ["export", "--out", "outputs/"])
-    assert result.exit_code == 0
-
 
     outdir = tmp_path / "out"
     result = runner.invoke(app, ["export", "--out", str(outdir)])
     assert result.exit_code == 0
     assert (outdir / "alignment.csv").exists()
 
- main
- main
     result = runner.invoke(app, ["report", "--id", "A000360"])
     assert result.exit_code == 0
-

--- a/tests/test_contribution_normalization.py
+++ b/tests/test_contribution_normalization.py
@@ -10,12 +10,6 @@ def test_contribution_normalization(raw_contribs):
     assert c.committee_id == "C1"
     assert c.amount == 1000
     assert c.cycle == 2024
- codex/create-reproducible-pipeline-for-fec-data-analysis-erh252
-
- codex/create-reproducible-pipeline-for-fec-data-analysis-bn84jr
-
     assert isinstance(c.date, date)
- main
- main
     assert c.date == date(2024, 1, 1)
 


### PR DESCRIPTION
## Summary
- Replace corrupted CLI with working ingest/normalize/export/report commands
- Simplify contribution normalization helpers
- Remove stray artifacts and rewrite tests to exercise the pipeline

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adfa9fbaf48323ad9d5906b68acb9d