### PR TITLE
chore: streamline workflows

### DIFF
--- a/.github/workflows/data.yml
+++ b/.github/workflows/data.yml
@@ -1,7 +1,5 @@
 name: Refresh data
 on:
-  push:
-    branches: [ main ]
   workflow_dispatch:
   schedule:
     - cron: '17 9 * * *'   # 09:17 UTC daily

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,6 +2,8 @@ name: Deploy site
 on:
   push:
     branches: [ main ]
+    paths:
+      - "**/*.html"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- run data refresh only on schedule or manual dispatch to avoid self-triggered loops
- deploy site only when HTML files change

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run validate` *(fails: Cannot find module 'scripts/validate.mjs')*


------
https://chatgpt.com/codex/tasks/task_e_68ae20ec4a0c832397093d585eb04ea1