### PR TITLE
Use shared data for accountability pages

### DIFF
--- a/accountability/financial-alignments.html
+++ b/accountability/financial-alignments.html
@@ -1,5 +1,5 @@
 <!-- financial-alignments.html — FULL, DROP‑IN PAGE
-     - Uses pipeline JSON if present: data/members.json, data/donors-by-member.json, data/member-awards.json, data/vote-alignments.json
+     - Uses pipeline JSON if present: ../data/members.json, ../data/donors-by-member.json, ../data/member-awards.json, ../data/vote-alignments.json
      - Also ships with inline demo data as a fallback so it renders out of the box.
      - Extras: client‑side filters, column sorting, CSV export, robust error handling, a11y tweaks. -->
 <!DOCTYPE html>
@@ -296,10 +296,10 @@
   // Load data (pipeline if present, else demo)
   $('#load-status').textContent = 'Loading data…';
   const [members, donorsByMember, awardsByMember, voteAlignByMember] = await Promise.all([
-    tryJSON('data/members.json','demo-members'),
-    tryJSON('data/donors-by-member.json','demo-donors'),
-    tryJSON('data/member-awards.json','demo-awards'),
-    tryJSON('data/vote-alignments.json','demo-align')
+    tryJSON('../data/members.json','demo-members'),
+    tryJSON('../data/donors-by-member.json','demo-donors'),
+    tryJSON('../data/member-awards.json','demo-awards'),
+    tryJSON('../data/vote-alignments.json','demo-align')
   ]);
   $('#load-status').textContent = 'Data loaded.';
 

--- a/accountability/index.backup.html
+++ b/accountability/index.backup.html
@@ -350,7 +350,7 @@ function partyLabel(code){
 async function loadMembers(){
   // 1) local mirror (fast, versioned)
   try{
-    const r = await fetch('data/members.json', {cache:'no-store'});
+    const r = await fetch('../data/members.json', {cache:'no-store'});
     if(r.ok){
       const local = await r.json();
       const norm = {};
@@ -397,7 +397,7 @@ async function loadMembers(){
 
 async function loadVotes(){
   try{
-    const r = await fetch('data/votes.json', {cache:'no-store'});
+    const r = await fetch('../data/votes.json', {cache:'no-store'});
     if(!r.ok) throw new Error('no votes file');
     return await r.json();
   }catch(e){

--- a/accountability/index.html
+++ b/accountability/index.html
@@ -270,7 +270,7 @@ function money(n){ return '$' + (Math.round(n||0)).toLocaleString(); }
 async function loadMembers(){
   const ver = (window.GIT_SHA || Date.now());
   try{
-    const r = await fetch(`data/members.json?v=${ver}`, {cache:'no-store'});
+    const r = await fetch(`../data/members.json?v=${ver}`, {cache:'no-store'});
     if(r.ok){
       const local = await r.json();
       const out = [];
@@ -328,9 +328,9 @@ async function loadJSON(path, fallback={}){
   }
 }
 
-async function loadDonors(){ return loadJSON('data/donors-by-member.json', {}); }
-async function loadAwards(){ return loadJSON('data/member-awards.json', {}); }
-async function loadAlign(){ return loadJSON('data/vote-alignments.json', {}); }
+async function loadDonors(){ return loadJSON('../data/donors-by-member.json', {}); }
+async function loadAwards(){ return loadJSON('../data/member-awards.json', {}); }
+async function loadAlign(){ return loadJSON('../data/vote-alignments.json', {}); }
 
 function topIndustry(d){
   if(!d || !d.industries) return {key:'—', share:0};


### PR DESCRIPTION
## Summary
- Pull accountability pages' data from the root `data/` folder instead of local `accountability/data`
- Point financial alignments page to shared JSON datasets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae25effaf48323aef1ba7e720c5ed9