### PR TITLE
Fix Wall of Shame image paths

### DIFF
--- a/accountability/index.html
+++ b/accountability/index.html
@@ -9,7 +9,7 @@
   <meta property="og:title" content="Wall of Shame — Faces, Votes, Receipts"/>
   <meta property="og:description" content="Filter by state or party. Every face has receipts and badges."/>
   <meta property="og:type" content="website"/>
-  <meta property="og:image" content="/assets/share-wall.png"/>
+  <meta property="og:image" content="https://via.placeholder.com/1200x630.png?text=Wall+of+Shame"/>
 
   <!-- Bootstrap + Icons -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"/>
@@ -412,11 +412,11 @@ function cardHTML(o){
     <img
       class="avatar"
       crossorigin="anonymous"
-      src="${('/images/' + o.bioguide + '.jpg')}"
+      src="https://unitedstates.github.io/images/congress/225x275/${o.bioguide}.jpg"
       alt="${o.name}"
       loading="lazy"
       decoding="async"
-      onerror="const b='${o.bioguide}';if(!this.dataset.s){this.dataset.s='1';this.src='images/Image'+b+'.jpg';}else if(this.dataset.s==='1'){this.dataset.s='2';this.src='https://unitedstates.github.io/images/congress/225x275/'+b+'.jpg';}else{this.onerror=null;this.src='data:image/svg+xml;utf8,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%22300%22 height=%22375%22><rect width=%22300%22 height=%22375%22 fill=%22%23e6edf3%22/><text x=%2250%25%22 y=%2250%25%22 dominant-baseline=%22middle%22 text-anchor=%22middle%22 font-family=%22Arial%22 font-size=%2214%22 fill=%22%23666%22>NO IMAGE</text></svg>'}"
+      onerror="this.onerror=null;this.src='data:image/svg+xml;utf8,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%22300%22 height=%22375%22><rect width=%22300%22 height=%22375%22 fill=%22%23e6edf3%22/><text x=%2250%25%22 y=%2250%25%22 dominant-baseline=%22middle%22 text-anchor=%22middle%22 font-family=%22Arial%22 font-size=%2214%22 fill=%22%23666%22>NO IMAGE</text></svg>'"
     />
     <div class="body">
       <div class="name">${o.name}</div>
@@ -525,10 +525,8 @@ function openProfile(bio){
   img.alt = member.name;
   img.src = `https://unitedstates.github.io/images/congress/225x275/${member.bioguide}.jpg`;
   img.onerror = function(){
-    const b = member.bioguide;
-    if(!this.dataset.s){ this.dataset.s='1'; this.src = `images/Image${b}.jpg`; }
-    else if(this.dataset.s==='1'){ this.dataset.s='2'; this.src = `images/Image${b}.jpg`; }
-    else { this.onerror=null; this.src='data:image/svg+xml;utf8,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%22120%22 height=%22150%22><rect width=%22120%22 height=%22150%22 fill=%22%23e6edf3%22/><text x=%2250%25%22 y=%2250%25%22 dominant-baseline=%22middle%22 text-anchor=%22middle%22 font-family=%22Arial%22 font-size=%2212%22 fill=%22%23666%22>NO IMAGE</text></svg>'; }
+    this.onerror = null;
+    this.src = 'data:image/svg+xml;utf8,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%22120%22 height=%22150%22><rect width=%22120%22 height=%22150%22 fill=%22%23e6edf3%22/><text x=%2250%25%22 y=%2250%25%22 dominant-baseline=%22middle%22 text-anchor=%22middle%22 font-family=%22Arial%22 font-size=%2212%22 fill=%22%23666%22>NO IMAGE</text></svg>';
   };
 
   document.getElementById('receiptName').textContent = member.name;


### PR DESCRIPTION
## Summary
- Use placeholder Open Graph image for Wall of Shame page
- Load congressional photos directly from remote source with simple SVG fallback

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae297fb1d88323b4f05b02a17c0650