### PR TITLE
chore: log data counts and shrink headshots

### DIFF
--- a/accountability/financial-alignments.html
+++ b/accountability/financial-alignments.html
@@ -301,6 +301,16 @@
     tryJSON('../data/member-awards.json','demo-awards'),
     tryJSON('../data/vote-alignments.json','demo-align')
   ]);
+  const memberCount = Array.isArray(members) ? members.length : Object.keys(members||{}).length;
+  const donorCount = Object.keys(donorsByMember||{}).length;
+  const awardCount = Object.keys(awardsByMember||{}).length;
+  const alignCount = Object.keys(voteAlignByMember||{}).length;
+  console.log(`Loaded ${memberCount} members, ${donorCount} donor records, ${awardCount} award records, ${alignCount} vote alignment records.`);
+  const badgeMembers = Object.values(awardsByMember||{}).filter(a=>Array.isArray(a.badges)&&a.badges.length).length;
+  console.log(`${badgeMembers} members have badges.`);
+  if(!memberCount || !donorCount || !awardCount || !alignCount){
+    console.warn('One or more datasets failed to load fully.');
+  }
   $('#load-status').textContent = 'Data loaded.';
 
   function pct(n){ return Math.round((n||0)*100); }

--- a/accountability/index.backup.html
+++ b/accountability/index.backup.html
@@ -52,7 +52,7 @@
     @keyframes sheen{0%{background-position:100% 0} 100%{background-position:0 0}}
     /* Thumbnail faces */
     .avatar{
-      width:80px; height:auto; aspect-ratio:4/5;
+      width:20px; height:auto; aspect-ratio:4/5;
       object-fit:cover; background:#e6edf3;
       display:block; margin:.5rem auto; border-radius:8px;
     }

--- a/accountability/index.html
+++ b/accountability/index.html
@@ -47,7 +47,7 @@
     .name{font-weight:800}
     .meta{color:var(--muted); font-size:.9rem}
     .avatar{
-      width:94%; max-width:220px; height:auto; aspect-ratio:4/5;
+      width:24%; max-width:55px; height:auto; aspect-ratio:4/5;
       object-fit:cover; background:#e6edf3; display:block; margin:.6rem auto; border-radius:10px;
     }
 
@@ -615,6 +615,15 @@ document.getElementById('resetFilters').addEventListener('click', ()=>{
 (async function init(){
   MEMBERS = await loadMembers();
   [DONORS, AWARDS, ALIGN] = await Promise.all([loadDonors(), loadAwards(), loadAlign()]);
+  const donorCount = Object.keys(DONORS).length;
+  const awardCount = Object.keys(AWARDS).length;
+  const alignCount = Object.keys(ALIGN).length;
+  console.log(`Loaded ${MEMBERS.length} members, ${donorCount} donor records, ${awardCount} award records, ${alignCount} alignment records.`);
+  const badgeMembers = Object.values(AWARDS).filter(a=>Array.isArray(a.badges)&&a.badges.length).length;
+  console.log(`${badgeMembers} members have badges.`);
+  if(!MEMBERS.length || !donorCount || !awardCount || !alignCount){
+    console.warn('One or more datasets failed to load fully.');
+  }
   buildFilters();
   joinData();
   render();


### PR DESCRIPTION
## Summary
- reduce Wall of Shame card headshots to one-quarter size
- log member, donor, award, alignment and badge counts on Wall of Shame and Financial Alignments pages, with warnings if data is missing

## Testing
- `pytest >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68ae5684f1cc8323938219b27d1a1896