### PR TITLE
Add voter history ingestion support

### DIFF
--- a/data/voter_history_sample.csv
+++ b/data/voter_history_sample.csv
@@ -1,0 +1,3 @@
+voter_id,election_date,participated,method
+V001,2022-11-08,True,Absentee
+V002,2022-11-08,False,

--- a/src/cli.py
+++ b/src/cli.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import typer
 
-from . import analyze, fec, load, normalize, votes
+from . import analyze, fec, load, normalize, votes, voter_history
 from .models import Member, MemberVote
 
 app = typer.Typer()
@@ -85,6 +85,14 @@ def ingest_votes(from_date: str = typer.Option(..., "--from")) -> None:
         for mid, pos in positions.items()
     ]
     load.load_objects(member_votes)
+
+
+@ingest_app.command("voter-history")
+def ingest_voter_history(path: str = typer.Option("data/voter_history_sample.csv", "--path")) -> None:
+    """Parse and store voter history records from a CSV file."""
+    load.init_db()
+    records = voter_history.parse_voter_history(path)
+    load.load_objects(records)
 
 
 @app.command("normalize")

--- a/src/models.py
+++ b/src/models.py
@@ -68,6 +68,14 @@ class MemberVote(SQLModel, table=True):
     position: str
 
 
+class VoterHistory(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    voter_id: str
+    election_date: date
+    participated: bool
+    method: Optional[str] = None
+
+
 class MemberFinance(SQLModel, table=True):
     member_id: str = Field(foreign_key="member.member_id", primary_key=True)
     cycle: int = Field(primary_key=True)

--- a/src/voter_history.py
+++ b/src/voter_history.py
@@ -1,0 +1,25 @@
+"""Utilities for loading voter history records."""
+from __future__ import annotations
+
+import csv
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, List
+
+from .models import VoterHistory
+
+
+def parse_voter_history(path: str | Path) -> List[VoterHistory]:
+    """Parse voter history CSV into ``VoterHistory`` objects."""
+    records: List[VoterHistory] = []
+    with Path(path).open() as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            record = VoterHistory(
+                voter_id=row["voter_id"],
+                election_date=datetime.strptime(row["election_date"], "%Y-%m-%d").date(),
+                participated=row["participated"].lower() == "true",
+                method=row.get("method") or None,
+            )
+            records.append(record)
+    return records

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -21,6 +21,8 @@ def test_cli_smoke(tmp_path):
     assert result.exit_code == 0
     result = runner.invoke(app, ["ingest", "votes", "--from", "2023-01-01"])
     assert result.exit_code == 0
+    result = runner.invoke(app, ["ingest", "voter-history", "--path", "data/voter_history_sample.csv"])
+    assert result.exit_code == 0
     result = runner.invoke(app, ["normalize", "all"])
     assert result.exit_code == 0
     result = runner.invoke(app, ["analyze", "--window", "24m"])

--- a/tests/test_voter_history_parser.py
+++ b/tests/test_voter_history_parser.py
@@ -1,0 +1,9 @@
+from src.voter_history import parse_voter_history
+
+
+def test_parse_voter_history():
+    records = parse_voter_history("data/voter_history_sample.csv")
+    assert len(records) == 2
+    assert records[0].voter_id == "V001"
+    assert records[0].participated is True
+    assert records[1].participated is False


### PR DESCRIPTION
## Summary
- add VoterHistory model and CSV parser
- wire voter-history ingestion command into CLI
- cover voter-history parsing and CLI in tests

## Testing
- `pytest -q`
- `python -m src.cli ingest voter-history --path data/voter_history_sample.csv`


------
https://chatgpt.com/codex/tasks/task_e_68ae58845ef88323ac72ced98e8fe3d2