### PR TITLE
Use default GitHub token for Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/configure-pages@v5
         with:
-          token: ${{ secrets.PAGES_TOKEN }}
+          token: ${{ secrets.PAGES_TOKEN || github.token }}
           enablement: true   # 👈 create/enable the Pages site if missing
       - uses: actions/upload-pages-artifact@v3
         with:
@@ -37,4 +37,4 @@ jobs:
       - id: deployment
         uses: actions/deploy-pages@v4
         with:
-          token: ${{ secrets.PAGES_TOKEN }}
+          token: ${{ secrets.PAGES_TOKEN || github.token }}


### PR DESCRIPTION
## Summary
- let Pages workflow fall back to `GITHUB_TOKEN`
- document optional `PAGES_TOKEN` usage
- reference FEC and Congress.gov repos and include provided API keys in README examples

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae694a190083239056e27575990d25