### PR TITLE
Add Schedule E ingestion and storage

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -42,8 +42,16 @@ def ingest_members() -> None:
 
 
 @ingest_app.command("fec")
-def ingest_fec(cycles: str = typer.Option(..., "--cycles")) -> None:
-    """Normalize and store a sample FEC contribution record."""
+def ingest_fec(
+    cycles: str = typer.Option(..., "--cycles"),
+    schedule_e: bool = typer.Option(
+        False, "--schedule-e", help="Include Schedule E data", is_flag=True
+    ),
+) -> None:
+    """Normalize and store a sample FEC contribution record.
+
+    Optionally include Schedule E independent expenditures.
+    """
     members = [{"member_id": "A000360", "bioguide_id": "A000360"}]
     mapping = {"A000360": ["H0XX00001"]}
     fec.link_members_to_candidates(members, mapping)
@@ -63,6 +71,11 @@ def ingest_fec(cycles: str = typer.Option(..., "--cycles")) -> None:
     ]
     contribs = normalize.normalize_contributions(raw)
     load.load_objects(contribs)
+
+    if schedule_e:
+        ie_raw = fec.fetch_independent_expenditures("H0XX00001", int(cycles))
+        expenditures = normalize.normalize_independent_expenditures(ie_raw)
+        load.load_objects(expenditures)
 
 
 @ingest_app.command("votes")

--- a/src/fec.py
+++ b/src/fec.py
@@ -36,6 +36,20 @@ def fetch_contributions(candidate_id: str, cycle: int) -> List[Dict]:
     return data.get("results", [])
 
 
+def fetch_independent_expenditures(candidate_id: str, cycle: int) -> List[Dict]:
+    """Fetch Schedule E independent expenditures for a candidate."""
+    settings = get_settings()
+    url = f"{API_URL}/schedules/schedule_e/"
+    params = {
+        "api_key": settings.fec_api_key,
+        "candidate_id": candidate_id,
+        "per_page": 20,
+        "cycle": cycle,
+    }
+    data = get_json(url, params=params)
+    return data.get("results", [])
+
+
 def link_members_to_candidates(members: Iterable[Dict[str, str]], mapping: Dict[str, List[str]]) -> Dict[str, List[str]]:
     """Link members to candidate IDs using provided mapping.
 

--- a/src/models.py
+++ b/src/models.py
@@ -41,6 +41,20 @@ class Contribution(SQLModel, table=True):
     cycle: int
 
 
+class IndependentExpenditure(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    committee_id: Optional[str] = Field(
+        default=None, foreign_key="committee.committee_id"
+    )
+    candidate_id: Optional[str] = None
+    payee: Optional[str] = None
+    purpose: Optional[str] = None
+    amount: float
+    date: date
+    support_oppose: Optional[str] = None
+    cycle: int
+
+
 class Bill(SQLModel, table=True):
     bill_id: str = Field(primary_key=True)
     congress: int

--- a/src/normalize.py
+++ b/src/normalize.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Dict, Iterable, List
 
-from .models import Contribution
+from .models import Contribution, IndependentExpenditure
 
 
 def normalize_contributions(records: Iterable[Dict]) -> List[Contribution]:
@@ -25,6 +25,30 @@ def normalize_contributions(records: Iterable[Dict]) -> List[Contribution]:
                 industry=r.get("industry"),
                 amount=float(r.get("amount", 0)),
                 date=date_val,
+                cycle=int(r.get("cycle", 0)),
+            )
+        )
+    return normalized
+
+
+def normalize_independent_expenditures(
+    records: Iterable[Dict],
+) -> List[IndependentExpenditure]:
+    """Convert raw schedule E dicts to :class:`IndependentExpenditure` objects."""
+    normalized: List[IndependentExpenditure] = []
+    for r in records:
+        date_val = r.get("date")
+        if isinstance(date_val, str):
+            date_val = datetime.strptime(date_val, "%Y-%m-%d").date()
+        normalized.append(
+            IndependentExpenditure(
+                committee_id=r.get("committee_id"),
+                candidate_id=r.get("candidate_id"),
+                payee=r.get("payee"),
+                purpose=r.get("purpose"),
+                amount=float(r.get("amount", 0)),
+                date=date_val,
+                support_oppose=r.get("support_oppose"),
                 cycle=int(r.get("cycle", 0)),
             )
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,22 @@ def raw_contribs() -> list[dict]:
 
 
 @pytest.fixture
+def raw_independent_expenditures() -> list[dict]:
+    return [
+        {
+            "committee_id": "C1",
+            "candidate_id": "H0XX00001",
+            "payee": "Media Co",
+            "purpose": "Ads",
+            "amount": 5000,
+            "date": "2024-02-01",
+            "support_oppose": "S",
+            "cycle": 2024,
+        }
+    ]
+
+
+@pytest.fixture
 def vote_record() -> dict:
     return {
         "positions": [

--- a/tests/test_cli_schedule_e.py
+++ b/tests/test_cli_schedule_e.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+from sqlmodel import Session, select
+from typer.testing import CliRunner
+
+from src.cli import app
+from src.models import IndependentExpenditure
+import src.fec as fec
+from src.load import get_engine
+
+
+def test_cli_ingest_schedule_e(monkeypatch):
+    runner = CliRunner()
+    db_path = Path("campaign.db")
+    if db_path.exists():
+        db_path.unlink()
+    result = runner.invoke(app, ["ingest", "members"])
+    assert result.exit_code == 0
+
+    sample = [
+        {
+            "committee_id": "C1",
+            "candidate_id": "H0XX00001",
+            "payee": "Media Co",
+            "purpose": "Ads",
+            "amount": 5000,
+            "date": "2024-02-01",
+            "support_oppose": "S",
+            "cycle": 2024,
+        }
+    ]
+
+    monkeypatch.setattr(fec, "fetch_independent_expenditures", lambda cid, cyc: sample)
+
+    result = runner.invoke(app, ["ingest", "fec", "--cycles", "2024", "--schedule-e"])
+    assert result.exit_code == 0
+
+    engine = get_engine()
+    with Session(engine) as session:
+        rows = session.exec(select(IndependentExpenditure)).all()
+        assert len(rows) == 1
+        assert rows[0].candidate_id == "H0XX00001"
+

--- a/tests/test_independent_expenditure_normalization.py
+++ b/tests/test_independent_expenditure_normalization.py
@@ -1,0 +1,17 @@
+from datetime import date
+
+from src.normalize import normalize_independent_expenditures
+
+
+def test_independent_expenditure_normalization(raw_independent_expenditures):
+    normalized = normalize_independent_expenditures(raw_independent_expenditures)
+    assert len(normalized) == 1
+    ie = normalized[0]
+    assert ie.committee_id == "C1"
+    assert ie.candidate_id == "H0XX00001"
+    assert ie.payee == "Media Co"
+    assert ie.amount == 5000
+    assert ie.cycle == 2024
+    assert isinstance(ie.date, date)
+    assert ie.date == date(2024, 2, 1)
+


### PR DESCRIPTION
## Summary
- support fetching FEC Schedule E independent expenditures
- allow CLI `ingest fec` command to optionally load Schedule E data
- normalize and persist schedule E records with new model
- test Schedule E parsing and CLI ingestion

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae6ceb07988323bdd4c78fc27c29ae