### PR TITLE
fix votes endpoint URL

### DIFF
--- a/scripts/pull-votes.mjs
+++ b/scripts/pull-votes.mjs
@@ -61,7 +61,7 @@ async function collectChamber(chamber){
   const out = {};
   // The API key is provided via header, so avoid leaking it in the request URL
   // which could be logged or cached. Rely solely on the header for auth.
-  let url = `${BASE}/votes/${chamber}?fromDateTime=${encodeURIComponent(sinceISO)}&format=json&limit=250`;
+  let url = `${BASE}/votes?chamber=${chamber}&fromDateTime=${encodeURIComponent(sinceISO)}&format=json&limit=250`;
   while (url) {
     const data = await getJSON(url);
     for (const v of data.votes || []) {


### PR DESCRIPTION
## Summary
- update votes API path to query chamber via query parameter

## Testing
- `CONGRESS_API_KEY=test node scripts/pull-votes.mjs` *(fails: HTTP 403 Domain forbidden)*
- `npm test` *(fails: Missing script "test" )*

------
https://chatgpt.com/codex/tasks/task_e_68ae7041711c8323b8e5ce884f83bfe7