### PR TITLE
Fail pull-donors when FEC_API_KEY or fallback CSV missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,12 @@ This populates `data/` and `accountability/data/` with donors, alignment, and ba
 
 ### FEC data without an API key
 
-If the OpenFEC API is unavailable, set the `FEC_FALLBACK_CSV` environment
-variable to a CSV file containing `candidate_id,total_receipts,individual_contributions,
-pac_contributions,transfers_from_other_authorized_committee` columns. The
-`scripts/pull-donors.mjs` script reads this file instead of calling the API.
+If the OpenFEC API is unavailable, you **must** set the `FEC_FALLBACK_CSV`
+environment variable to a CSV file containing
+`candidate_id,total_receipts,individual_contributions,pac_contributions,transfers_from_other_authorized_committee`
+columns. The `scripts/pull-donors.mjs` script reads this file instead of
+calling the API and will exit with an error if neither `FEC_API_KEY` nor a
+fallback CSV is provided.
 
 ### Sample API calls
 


### PR DESCRIPTION
## Summary
- exit the donor pull script when neither `FEC_API_KEY` nor `FEC_FALLBACK_CSV` is provided
- document that a fallback CSV is required if the API key is absent

## Testing
- `FEC_FALLBACK_CSV=/tmp/fallback.csv node scripts/pull-donors.mjs`
- `npm test` (fails: Missing script: "test")
- `poetry run pytest -q` (fails: ProxyError: Unable to connect to proxy)


------
https://chatgpt.com/codex/tasks/task_e_68ae7098c8988323b88c41c6824f9397