### PR TITLE
Use GITHUB_TOKEN for Pages deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,7 +22,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/configure-pages@v5
         with:
-          token: ${{ secrets.PAGES_TOKEN || github.token }}
           enablement: true   # 👈 create/enable the Pages site if missing
       - uses: actions/upload-pages-artifact@v3
         with:
@@ -36,5 +35,3 @@ jobs:
     steps:
       - id: deployment
         uses: actions/deploy-pages@v4
-        with:
-          token: ${{ secrets.PAGES_TOKEN || github.token }}

--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@ to backfill the dataset if the API is unavailable.
 
 ## GitHub Pages Deployment
 
-The project deploys its static site with GitHub Pages via `.github/workflows/pages.yml`. The workflow
-uses the default `GITHUB_TOKEN`, but will also accept a personal access token supplied as the
-`PAGES_TOKEN` secret. Provide a token with `repo` and `pages:write` scopes if you need to create or
-enable the Pages site; otherwise the built-in token is sufficient for routine deployments.
+The project deploys its static site with GitHub Pages via `.github/workflows/pages.yml`.
+The workflow relies solely on the built-in `GITHUB_TOKEN`, which is granted the
+`pages:write` permission for publishing. No personal access token is required for
+deployments.
 
 ## Congress.gov API curl examples
 


### PR DESCRIPTION
## Summary
- simplify GitHub Pages workflow to use built-in token
- clarify deployment docs

## Testing
- `poetry run flake8 src tests` *(fails: Command not found: flake8)*
- `poetry run pytest -q` *(fails: assert 1 == 0 due to ProxyError)*

------
https://chatgpt.com/codex/tasks/task_e_68af18694b248323b5d5e8eee4cff81e