### PR TITLE
Fix stray token causing pull-votes error

### DIFF
--- a/scripts/pull-votes.mjs
+++ b/scripts/pull-votes.mjs
@@ -64,7 +64,6 @@ async function collectChamber(chamber){
   // The API key is provided via header, so avoid leaking it in the request URL
   // which could be logged or cached. Rely solely on the header for auth.
   let url = `${BASE}/votes?chamber=${chamber}&fromDateTime=${encodeURIComponent(sinceISO)}&format=json&limit=250`;
- main
   while (url) {
     const data = await getJSON(url);
     for (const v of data.votes || []) {


### PR DESCRIPTION
## Summary
- remove stray `main` token in pull-votes script that caused `main is not defined`

## Testing
- `CONGRESS_API_KEY=bogus node scripts/pull-votes.mjs`
- `/tmp/venv/bin/poetry run pytest -q` *(fails: ProxyError)*

------
https://chatgpt.com/codex/tasks/task_e_68af154a4b6c832390ae7aca45ccb555