### PR TITLE
Add bulk candidate totals download using FEC data

### DIFF
--- a/tests/test_fec_api.py
+++ b/tests/test_fec_api.py
@@ -1,4 +1,7 @@
 from src import fec
+import shutil
+import zipfile
+import urllib.request
 
 
 def test_fetch_candidate_totals_pagination(monkeypatch):
@@ -40,3 +43,18 @@ def test_fetch_independent_expenditures_pagination(monkeypatch):
     monkeypatch.setattr(fec, "get_json", fake_get_json)
     data = fec.fetch_independent_expenditures("H0XX00001", 2024)
     assert len(data) == 3
+
+
+def test_fetch_candidate_totals_bulk(monkeypatch, tmp_path):
+    data = "CAND_ID,TTL_RECEIPTS\nH0XX00001,100\nH0XX00002,50\n"
+    zip_file = tmp_path / "ccl.csv.zip"
+    with zipfile.ZipFile(zip_file, "w") as z:
+        z.writestr("ccl.csv", data)
+
+    def fake_urlretrieve(url, dest):
+        shutil.copy(zip_file, dest)
+        return str(dest), None
+
+    monkeypatch.setattr(urllib.request, "urlretrieve", fake_urlretrieve)
+    rows = fec.fetch_candidate_totals("H0XX00001", 2024, bulk=True)
+    assert rows == [{"CAND_ID": "H0XX00001", "TTL_RECEIPTS": "100"}]


### PR DESCRIPTION
## Summary
- Support downloading candidate totals from FEC bulk CSV files
- Test candidate totals bulk download logic

## Testing
- `poetry run flake8 src tests` *(fails: line too long and other style issues)*
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68af2730800c83238602ff5523186c0e