### PR TITLE
Include congress-legislators dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ make dev
 
 ### GitHub data sources
 
-Clone upstream repositories for legislative and finance data and point the
-pipeline at them with environment variables:
+Clone upstream repositories for legislator metadata, legislative data, and
+finance data. The helper script also fetches the
+`unitedstates/congress-legislators` repository, which provides the Bioguide ↔ FEC
+ID crosswalk used to join votes with campaign finance records.
 
 ```bash
 python scripts/pull_sources.py

--- a/scripts/pull_sources.py
+++ b/scripts/pull_sources.py
@@ -5,8 +5,12 @@ import subprocess
 
 REPOS = {
     "unitedstates-congress": "https://github.com/unitedstates/congress",
+    "congress-legislators": (
+        "https://github.com/unitedstates/congress-legislators"
+    ),
     "openFEC": "https://github.com/fecgov/openFEC",
 }
+
 
 def main() -> None:
     base = Path("data") / "sources"
@@ -14,9 +18,13 @@ def main() -> None:
     for name, url in REPOS.items():
         dest = base / name
         if dest.exists():
-            subprocess.run(["git", "-C", str(dest), "pull", "--ff-only"], check=True)
+            subprocess.run(
+                ["git", "-C", str(dest), "pull", "--ff-only"],
+                check=True,
+            )
         else:
             subprocess.run(["git", "clone", url, str(dest)], check=True)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- add `congress-legislators` repository to `pull_sources.py` so ID crosswalk data is pulled with other GitHub sources
- document the crosswalk dataset in README

## Testing
- `poetry run flake8 scripts/pull_sources.py`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af27555e1c8323b91214f597dd25b0