### PR TITLE
docs: mention Data.world FEC bulk dataset mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ curl "https://api.open.fec.gov/v1/schedules/schedule_e/?per_page=100&api_key=nla
 
 Bulk CSVs for full backfills are available from <https://www.fec.gov/data/browse-data/>.
 
+Alternatively, [Data.world](https://data.world/fec) hosts mirrored FEC bulk datasets that you can download or query via SQL in the browser for free.
+
 #### Congress.gov examples
 
 ```bash


### PR DESCRIPTION
## Summary
- Document Data.world's free mirror of FEC bulk datasets for CSV downloads or SQL queries

## Testing
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af27780a10832396e808a7850517e5