### PR TITLE
Add Voteview ideology download script

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ export CONGRESS_DATA_DIR="data/sources/unitedstates-congress"
 export FEC_DATA_DIR="data/sources/openFEC"
 ```
 
+### Voteview ideology scores
+
+Download DW-NOMINATE scores for historical and current members of Congress:
+
+```bash
+node scripts/pull-voteview.mjs
+```
+
+The script retrieves the combined House and Senate member file from [Voteview](https://voteview.com/data) and writes
+`data/voteview_members.csv`, which can be joined with campaign finance or roll-call data via bioguide identifiers.
+
 ## Run End-to-End
 
 ```bash

--- a/scripts/pull-voteview.mjs
+++ b/scripts/pull-voteview.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+import fs from "node:fs/promises";
+import { createWriteStream } from "node:fs";
+import fetch from "node-fetch";
+import zlib from "node:zlib";
+import { pipeline } from "node:stream/promises";
+import { HttpsProxyAgent } from "https-proxy-agent";
+
+// Download combined House and Senate member ideology scores from Voteview.
+const SRC = "https://voteview.com/static/data/out/members/HSall_members.csv.zip";
+
+const proxy = process.env.https_proxy || process.env.http_proxy;
+const agent = proxy ? new HttpsProxyAgent(proxy) : undefined;
+
+try {
+  const res = await fetch(SRC, { agent });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  await fs.mkdir("data", { recursive: true });
+  const file = createWriteStream("data/voteview_members.csv");
+  await pipeline(res.body, zlib.createUnzip(), file);
+  console.log("✅ wrote data/voteview_members.csv");
+} catch (e) {
+  console.error("❌ pull-voteview failed:", e.message || e);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add `pull-voteview.mjs` script to fetch DW-NOMINATE scores from Voteview
- document Voteview download step in README

## Testing
- `node scripts/pull-voteview.mjs` (fails: HTTP 403)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af27856e788323bcee65d9c423f977